### PR TITLE
fix of compose error

### DIFF
--- a/incsender_standalone/init.sh
+++ b/incsender_standalone/init.sh
@@ -104,9 +104,9 @@ echo " "
 echo "+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
 echo " "
 
-if command -v docker-compose &> /dev/null; then
+if command -v docker-compose &> /dev/null && docker-compose --version &> /dev/null; then
     compose_cmd="docker-compose"
-elif command -v docker &> /dev/null && docker --version | grep -q "compose"; then
+elif command -v docker &> /dev/null && docker compose version &> /dev/null; then
     compose_cmd="docker compose"
 else
     echo "Error: Neither 'docker-compose' nor 'docker compose' command found. Please install docker & docker-compose first."


### PR DESCRIPTION
**Проблема**:  раньше при запуске скрипта `init.sh` всегда вылезала ошибка `Error: Neither 'docker-compose' nor 'docker compose' command found. Please install docker & docker-compose first` независимо от того, установлен ли докер с модулем compose или нет (даже под root). Предположу, что это относится к тем, у кого корректно отрабатывало бы именно `docker compose`, а не `docker-compose`, поэтому баг не был обнаружен ранее.

**Объяснение**: неправильная интерпретации команды `command -v docker compose`.

Команда `command -v docker compose` ищет две отдельные команды: `docker` и `compose`. Однако `docker compose` - это *субкоманда* docker, а не отдельная команда. Если выполнять команду `command -v docker compose`, она находит `docker` и затем `compose`, как будто это два независимых исполняемых файла.

**Решение**
Вместо проверки `command -v docker compose` нужно проверять только `docker`, а затем тестировать, поддерживает ли он *субкоманду* `compose`.

Fix протестирован на docker с модулем compose. Скрипт завершился успешно, контейнер запустился.